### PR TITLE
make SolutionInspector work without config files

### DIFF
--- a/SolutionInspector/Model/Persistence/SolutionReader.cs
+++ b/SolutionInspector/Model/Persistence/SolutionReader.cs
@@ -57,7 +57,9 @@ namespace SolutionInspector.Model.Persistence
             IProjectSettings projectSettings,
             ICollection<string> files)
         {
-            HashSet<string> ignoreSet = new HashSet<string>(ignoredProjects);
+            HashSet<string> ignoreSet = new HashSet<string>();
+            if (ignoredProjects != null)
+                ignoreSet.SetEquals(ignoredProjects);
             Context context = Context.None;
 
             foreach (string line in lines)

--- a/SolutionInspector/Rules/ProjectPropertiesMatchingRule.cs
+++ b/SolutionInspector/Rules/ProjectPropertiesMatchingRule.cs
@@ -11,7 +11,7 @@ namespace SolutionInspector.Rules
         {
             foreach (IProject project in solution.Projects)
             {
-                if (project.Settings.Properties == null)
+                if (project.Settings.Properties == null || project.Settings.Properties.Count() == 0)
                 {
                     continue;
                 }

--- a/SolutionInspector/Settings/Persistence/SettingsReader.cs
+++ b/SolutionInspector/Settings/Persistence/SettingsReader.cs
@@ -38,7 +38,7 @@ namespace SolutionInspector.Settings.Persistence
                 }
             }
 
-            return null;
+            return new ProjectSettings();
         }
     }
 }

--- a/SolutionInspector/Settings/ProjectSettings.cs
+++ b/SolutionInspector/Settings/ProjectSettings.cs
@@ -6,6 +6,16 @@ namespace SolutionInspector.Settings
 {
     internal class ProjectSettings : IProjectSettings
     {
+        public ProjectSettings()
+        {
+            DetectMissingFiles = true;
+            AllowBuildEvents = true;
+            AssemblyNameIsProjectName = true;
+            RootNamespaceIsAssemblyName = false;
+            RequiredImports = new List<string>();
+            Properties = new List<IProjectProperty>();
+        }
+
         public ProjectSettings(
             bool? detectMissingFiles,
             bool? allowBuildEvents,


### PR DESCRIPTION
I just tested your SolutionInspector against a mid-sized MSVC 2013 Solution with mostly C++ and some Python, Qt and custom-batch projects.
It failed to run due to several NULL access exceptions. I'm not a C-Sharpie, but figured out how to work around it.
I managed to make SolutionInspector run without requiring me to write XML config files for all my (45) projects.

If you think these are good changes, then please accept this PR.

Thanks,
Peter